### PR TITLE
STEP Merge tables from snowflake

### DIFF
--- a/steps/merge_tables_from_snowflake/README.md
+++ b/steps/merge_tables_from_snowflake/README.md
@@ -1,4 +1,3 @@
-```
 # Step de Mesclar Tabelas no Snowflake
 
 Este STEP permite mesclar tabelas alvo no Snowflake usando dados de entrada fornecidos de algum processo anterior ou mesmo de outro ativo de dados no Snowflake. O STEP possui uma feature que procura compatibilizar os DataTypes entre as colunas das tabelas Source e Target.

--- a/steps/merge_tables_from_snowflake/README.md
+++ b/steps/merge_tables_from_snowflake/README.md
@@ -1,0 +1,55 @@
+```
+# Step de Mesclar Tabelas no Snowflake
+
+Este STEP permite mesclar tabelas alvo no Snowflake usando dados de entrada fornecidos de algum processo anterior ou mesmo de outro ativo de dados no Snowflake. O STEP possui uma feature que procura compatibilizar os DataTypes entre as colunas das tabelas Source e Target.
+
+## Recursos
+
+- Mescla tabelas do Snowflake com base em colunas especificadas.
+- Suporta execução como parte de uma orquestração ou como um script autônomo.
+- Flexibilidade na configuração das tabelas de origem e de destino, bem como das colunas usadas para a fusão.
+
+## Requisitos
+
+- Python 3.x
+- Biblioteca do Snowflake
+- Biblioteca Pandas
+- Biblioteca Snowpark
+
+## Uso
+
+### Execução como parte de uma Orquestração
+
+Quando executado como parte de uma orquestração, este STEP espera os seguintes parâmetros:
+
+- `secret_id`: As credenciais do cliente no Snowflake.
+- `source_table`: O nome da tabela de origem no Snowflake ou os dados de saída de um step anterior em formato DataFrame do Pandas, em lista de dicionários ou arquivos .csv, .json e .parquet.
+- `target_table`: O nome da tabela de destino no Snowflake.
+- `source_on`: As colunas na tabela de origem para a junção.
+- `target_on`: As colunas na tabela de destino para a junção.
+
+### Execução como um Script Autônomo
+
+Para executar o STEP como um script autônomo, forneça os parâmetros de configuração em um arquivo JSON. Aqui está um exemplo de configuração:
+
+```json
+{
+    "secret_id": "snowflake_secret_id",
+    "source_table": "nome_da_tabela_origem",
+    "target_table": "nome_da_tabela_destino",
+    "source_on": ["coluna1", "coluna2"],
+    "target_on": ["coluna3", "coluna4"]
+}
+```
+
+Salve a configuração acima em um arquivo (por exemplo, `config.json`) e execute o script da seguinte forma:
+
+```
+python merge_tables_from_snowflake.py config.json
+```
+
+Substitua `config.json` pelo caminho do seu arquivo de configuração.
+
+## Saída
+
+Esse step `merge_tables_from_snowflake` deve ser utilizado como step final de uma pipeline, assim sendo, a variável **source_table** pode receber o mesmo nome da variável de saída do step anterior, se este step produzir um Pandas DataFrame, ou objeto que pode ser transformado em DataFrame.

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py
@@ -1,0 +1,84 @@
+from dadosfera.services.snowflake import get_snowpark_session
+from snowflake.snowpark import functions as F
+from typing import List, Dict
+import logging
+import json
+import sys
+import os
+
+logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+ORCHEST_STEP_UUID = os.environ.get('ORCHEST_STEP_UUID')
+
+def merge_tables_from_snowflake(
+        secret_id: str,
+        snowflake_queries_left: Dict,
+        snowflake_queries_right: Dict,
+        columns_to_merge: List[str]
+    ) -> List[str]:
+    import pandas as pd
+    session = get_snowpark_session(secret_id)
+    target = session.sql(snowflake_queries_left['queries'][0]).to_pandas()
+    source = session.sql(snowflake_queries_right['queries'][0]).to_pandas()
+    df = target.merge(source, left_on=columns_to_merge[0], right_on=columns_to_merge[1]) 
+    return df
+
+def orchest_handler():
+    import orchest
+    secret_id = orchest.get_step_param('secret_id')
+    left_table = orchest.get_step_param('left_table')
+    right_table = orchest.get_step_param('right_table')
+    columns_to_merge = orchest.get_step_param('columns_to_merge')
+    output_variable_name = orchest.get_step_param('output_variable_name')
+    
+    snowflake_queries_left = orchest.get_inputs()[left_table]
+    snowflake_queries_right = orchest.get_inputs()[right_table]
+    
+    queries = merge_tables_from_snowflake(
+        secret_id=secret_id,
+        snowflake_queries_left=snowflake_queries_left,
+        snowflake_queries_right=snowflake_queries_right,
+        columns_to_merge=columns_to_merge
+    )
+    
+    logger.info(f'Adding the following output to orchest: {queries}')
+    orchest.output(data=queries, name=output_variable_name)
+
+def script_handler():
+    if len(sys.argv) != 2:
+        raise Exception("Please provide the required configuration in JSON format")
+    config_json = sys.argv[1]
+    config = json.loads(config_json)
+
+    secret_id = config.get('secret_id')
+    input_filepath_left = config.get('input_filepath_left')
+    input_filepath_right = config.get('input_filepath_right')
+    output_filepath = config.get('output_filepath')
+    columns_to_merge = config.get('columns_to_merge')
+    
+    with open(input_filepath_left) as f:
+        snowflake_queries_left = json.loads(f.read())
+
+    with open(input_filepath_right) as f:
+        snowflake_queries_right = json.loads(f.read())
+        
+    queries = merge_tables_from_snowflake(
+        secret_id=secret_id,
+        snowflake_queries_left=snowflake_queries_left,
+        snowflake_queries_right=snowflake_queries_right,
+        columns_to_merge=columns_to_merge
+    )
+    with open(output_filepath,'w') as f:
+        f.write(json.dumps(queries))
+
+if __name__ == "__main__":
+
+    if ORCHEST_STEP_UUID is not None:
+        logger.info("Running as Orchest Step")
+        orchest_handler()
+    else:
+        logger.info("Running as script")
+        script_handler()

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py
@@ -1,81 +1,172 @@
 from dadosfera.services.snowflake import get_snowpark_session
-from snowflake.snowpark import functions as F
-from typing import List, Dict
+from snowflake import snowpark
+import pandas as pd
+from typing import List, Dict, Union
 import logging
 import json
 import sys
 import os
 
+# Set up logging
 logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger(__name__)
+
+# Set logger level to DEBUG
 logger.setLevel(logging.DEBUG)
 
+# Get ORCHEST_STEP_UUID from environment variable
 ORCHEST_STEP_UUID = os.environ.get('ORCHEST_STEP_UUID')
+
 
 def merge_tables_from_snowflake(
         secret_id: str,
-        snowflake_queries_left: Dict,
-        snowflake_queries_right: Dict,
-        columns_to_merge: List[str]
-    ) -> List[str]:
-    import pandas as pd
+        source_table: Union[pd.DataFrame, str, List[Dict[str, Union[str, bytes]]]],
+        target_table: str,
+        source_on: List[str],
+        target_on: List[str]
+    ) -> None:
+    """Merge tables from Snowflake using provided queries and columns."""
+    
+    # Get Snowpark session
     session = get_snowpark_session(secret_id)
-    target = session.sql(snowflake_queries_left['queries'][0]).to_pandas()
-    source = session.sql(snowflake_queries_right['queries'][0]).to_pandas()
-    df = target.merge(source, left_on=columns_to_merge[0], right_on=columns_to_merge[1]) 
-    return df
+    session.use_schema(target_table.split(".")[0])
+    
+    # Execute Snowflake query to load target table
+    target = session.table(target_table)
 
-def orchest_handler():
-    import orchest
-    secret_id = orchest.get_step_param('secret_id')
-    left_table = orchest.get_step_param('left_table')
-    right_table = orchest.get_step_param('right_table')
-    columns_to_merge = orchest.get_step_param('columns_to_merge')
-    output_variable_name = orchest.get_step_param('output_variable_name')
+    # Check the type of source_table and convert to snowpark DataFrame if necessary
+    if isinstance(source_table, pd.DataFrame):
+        schema = get_target_schema(target)
+        source = session.create_dataframe(source_table, schema)
+    elif isinstance(source_table, list):
+        schema = get_target_schema(target)
+        source = session.create_dataframe(source_table, schema)
+    elif isinstance(source_table, str):
+        source = session.table(source_table)
+    else:
+        raise ValueError("source_table must be table from snowflake, a pandas DataFrame or a list of dictionaries.")
     
-    snowflake_queries_left = orchest.get_inputs()[left_table]
-    snowflake_queries_right = orchest.get_inputs()[right_table]
-    
-    queries = merge_tables_from_snowflake(
-        secret_id=secret_id,
-        snowflake_queries_left=snowflake_queries_left,
-        snowflake_queries_right=snowflake_queries_right,
-        columns_to_merge=columns_to_merge
+    # Construct merge condition
+    condition_clause = snowpark.functions.lit(True)
+    for i, (source_col, target_col) in enumerate(zip(source_on, target_on)):
+        condition_clause &= (target[target_col] == source[source_col])
+
+    # Prepare update and insert clauses
+    update_set_clause = {col: source[col] for col in source.columns if col in target.columns}
+    insert_set_clause = {col: source[col] for col in source.columns}
+
+    # Merge tables
+    target.merge(
+        source=source,
+        join_expr=condition_clause,
+        clauses=[
+            snowpark.functions.when_matched().update(update_set_clause),
+            snowpark.functions.when_not_matched().insert(insert_set_clause)
+        ],
+        statement_params={"ERROR_ON_NONDETERMINISTIC_MERGE": False}
     )
+
     
-    logger.info(f'Adding the following output to orchest: {queries}')
-    orchest.output(data=queries, name=output_variable_name)
+def orchest_handler():
+    """Orchest handler for running as part of an orchestration."""
+    
+    import orchest
+    
+    # Get parameters from orchest
+    secret_id = orchest.get_step_param('secret_id')
+    source_table_name = orchest.get_step_param('source_table')
+    target_table = orchest.get_step_param('target_table')
+    source_on = orchest.get_step_param('source_on')
+    target_on = orchest.get_step_param('target_on')
+    try:
+        source_table = orchest.get_inputs()[source_table_name]
+    except KeyError:
+        source_table = source_table_name
+    
+    # Merge tables
+    merge_tables_from_snowflake(
+        secret_id=secret_id,
+        source_table=source_table,
+        target_table=target_table,
+        source_on=source_on,
+        target_on=target_on
+    )
+
 
 def script_handler():
+    """Script handler for running from command line with JSON configuration."""
+    
     if len(sys.argv) != 2:
         raise Exception("Please provide the required configuration in JSON format")
+    
+    # Load configuration from JSON
     config_json = sys.argv[1]
     config = json.loads(config_json)
 
+    # Extract configuration parameters
     secret_id = config.get('secret_id')
-    input_filepath_left = config.get('input_filepath_left')
-    input_filepath_right = config.get('input_filepath_right')
-    output_filepath = config.get('output_filepath')
-    columns_to_merge = config.get('columns_to_merge')
+    input_filepath_source = config.get('input_filepath_source')
+    source_on = config.get('source_on')
+    target_on = config.get('target_on')
     
-    with open(input_filepath_left) as f:
-        snowflake_queries_left = json.loads(f.read())
-
-    with open(input_filepath_right) as f:
-        snowflake_queries_right = json.loads(f.read())
+    # Load source data from file
+    if input_filepath_source.endswith('.csv'):
+        source_table = pd.read_csv(input_filepath_source)
+    elif input_filepath_source.endswith('.json'):
+        source_table = pd.read_json(input_filepath_source)
+    elif input_filepath_source.endswith('.parquet'):
+        source_table = pd.read_parquet(input_filepath_source, engine='fastparquet')
+    else:
+        raise ValueError("input_filepath_source must be a path to a .csv, .json or .parquet file.")
         
-    queries = merge_tables_from_snowflake(
+    # Merge tables
+    merge_tables_from_snowflake(
         secret_id=secret_id,
-        snowflake_queries_left=snowflake_queries_left,
-        snowflake_queries_right=snowflake_queries_right,
-        columns_to_merge=columns_to_merge
+        source_table=source_table,
+        target_table=config.get('target_table'),
+        source_on=source_on,
+        target_on=target_on
     )
-    with open(output_filepath,'w') as f:
-        f.write(json.dumps(queries))
+
+    
+def get_target_schema(target):
+    """Script to get the schema of the target table to handle datatypes transformation."""
+    
+    # Initialize an empty list to hold the schema fields
+    schema_fields = []
+
+    # Iterate over the target schema fields
+    for tgt_field in target.schema.fields:
+        # Get the field name and datatype
+        field_name = tgt_field.column_identifier.name
+        field_datatype = str(tgt_field.datatype).split('(')[0].strip()
+
+        # Map the datatype string to the corresponding Snowpark datatype
+        if field_datatype == 'StringType':
+            datatype = snowpark.types.StringType()
+        elif field_datatype == 'IntegerType':
+            datatype = snowpark.types.IntegerType()
+        elif field_datatype == 'ArrayType':
+            datatype = snowpark.types.ArrayType()
+        elif field_datatype == 'VariantType':
+            datatype = snowpark.types.VariantType()
+        elif field_datatype == 'TimestampType':
+            datatype = snowpark.types.TimestampType()
+        elif field_datatype == 'DateType':
+            datatype = snowpark.types.DateType()
+        # Create a StructField with the field name and datatype
+        struct_field = snowpark.types.StructField(field_name, datatype)
+
+        # Add the StructField to the schema fields list
+        schema_fields.append(struct_field)
+
+    # Create a StructType with the schema fields and return schema
+    return snowpark.types.StructType(schema_fields)
+
 
 if __name__ == "__main__":
 
+    # Determine whether running as Orchest step or script
     if ORCHEST_STEP_UUID is not None:
         logger.info("Running as Orchest Step")
         orchest_handler()

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.schema.json
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.schema.json
@@ -1,33 +1,36 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Merge Tables from Snowflake in Pandas Dataframe",
-    "description": "Schema for input validation to the function merge_tables_from_snowflake",
-    "type": "object",
-    "properties": {
-    "secret_id": {
-        "type": "string",
-        "description": "The id of the secret"
-    },
-    "left_table": {
-      "default": "Type of run of the step",
-      "type": "string"
-    },
-    "right_table": {
-      "default": "Type of run of the step",
-      "type": "string"
-    },
-    "columns_to_merge": {
-        "type": "array",
-        "minItems": 1,
-        "items": {
-          "description": "Columns to merge on left and right",
-          "type": "string"
-        }
-      },  
-    "output_variable_name": {
-        "default": "The output variable name",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Merge objects in snowflake",
+  "type": "object",
+  "properties": {
+  "secret_id": {
+      "type": "string",
+      "description": "SecretsManager secret_id"
+  },
+  "source_table": {
+    "default": "Source table to merge ",
+    "type": "string"
+  },
+  "target_table": {
+    "default": "Target table from Snowflake to merge",
+    "type": "string"
+  },
+  "source_on": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "description": "List of columns to merge on from Source table",
         "type": "string"
       }
     },
-    "required": ["secret_id", "left_table", "right_table", "output_variable_name", "columns_to_merge"]
+  "target_on": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "description": "List of columns to merge on from Target table",
+        "type": "string"
+      }
+    }
+  },
+  "required": ["secret_id", "source_table", "target_table", "source_on", "target_on"]
 }

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.schema.json
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Merge Tables from Snowflake in Pandas Dataframe",
+    "description": "Schema for input validation to the function merge_tables_from_snowflake",
+    "type": "object",
+    "properties": {
+    "secret_id": {
+        "type": "string",
+        "description": "The id of the secret"
+    },
+    "left_table": {
+      "default": "Type of run of the step",
+      "type": "string"
+    },
+    "right_table": {
+      "default": "Type of run of the step",
+      "type": "string"
+    },
+    "columns_to_merge": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "description": "Columns to merge on left and right",
+          "type": "string"
+        }
+      },  
+    "output_variable_name": {
+        "default": "The output variable name",
+        "type": "string"
+      }
+    },
+    "required": ["secret_id", "left_table", "right_table", "output_variable_name", "columns_to_merge"]
+}

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.uischema.json
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.uischema.json
@@ -1,0 +1,54 @@
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/output_variable_name",
+          "label": "Output Variable Name"
+        }]
+    },
+    {
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/secret_id",
+          "label": "Secrets Manager Secret ID"
+        }]
+    },
+    {
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/left_table",
+          "label": "Incoming Variable Name of Left Table"
+        }
+      ]
+    },
+    {
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/right_table",
+          "label": "Incoming Variable Name of Right Table"
+        }
+      ]
+    },
+    {
+      "type": "HorizontalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/columns_to_remove",
+          "label": "Columns To Merge"
+        }
+      ]
+    }
+  ]
+
+}

--- a/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.uischema.json
+++ b/steps/merge_tables_from_snowflake/merge_tables_from_snowflake.py.uischema.json
@@ -1,54 +1,55 @@
 {
   "type": "VerticalLayout",
   "elements": [
-    {
-      "type": "HorizontalLayout",
-      "elements": [
         {
-          "type": "Control",
-          "scope": "#/properties/output_variable_name",
-          "label": "Output Variable Name"
-        }]
-    },
-    {
-      "type": "HorizontalLayout",
-      "elements": [
+          "type": "HorizontalLayout",
+          "elements": [
+            {
+              "type": "Control",
+              "scope": "#/properties/secret_id",
+              "label": "SecretsManager secret_id"
+            }
+          ]
+        },
         {
-          "type": "Control",
-          "scope": "#/properties/secret_id",
-          "label": "Secrets Manager Secret ID"
-        }]
-    },
-    {
-      "type": "HorizontalLayout",
-      "elements": [
+          "type": "HorizontalLayout",
+          "elements": [
+            {
+                "type": "Control",
+                "scope": "#/properties/source_table",
+                "label": "Source Table (pd.DataFrame, List of Dictionaries or path name from table at Snowflake)"
+            }
+          ]
+        },
         {
-          "type": "Control",
-          "scope": "#/properties/left_table",
-          "label": "Incoming Variable Name of Left Table"
+          "type": "HorizontalLayout",
+          "elements": [
+            {
+                "type": "Control",
+                "scope": "#/properties/target_table",
+                "label": "Target Table \"PUBLIC\".\"TABLE_NAME\""
+            }
+          ]
+        },
+        {
+          "type": "HorizontalLayout",
+          "elements": [
+            {
+                "type": "Control",
+                "scope": "#/properties/source_on",
+                "label": "List of columns to Merge on from Source Table"
+            }
+          ]
+        },
+        {
+          "type": "HorizontalLayout",
+          "elements": [
+            {
+                "type": "Control",
+                "scope": "#/properties/target_on",
+                "label": "List of columns to Merge on from Target Table"
+            }
+          ]
         }
-      ]
-    },
-    {
-      "type": "HorizontalLayout",
-      "elements": [
-        {
-          "type": "Control",
-          "scope": "#/properties/right_table",
-          "label": "Incoming Variable Name of Right Table"
-        }
-      ]
-    },
-    {
-      "type": "HorizontalLayout",
-      "elements": [
-        {
-          "type": "Control",
-          "scope": "#/properties/columns_to_remove",
-          "label": "Columns To Merge"
-        }
-      ]
-    }
   ]
-
 }


### PR DESCRIPTION
This STEP allows you to merge target tables in Snowflake using input data provided from some previous process or even another data asset in Snowflake. STEP has a feature that seeks to make DataTypes compatible between the columns of the Source and Target tables.

Test evidences:

1. Merge 2 assets from Snowflake

    Step merge transient.calls with 119 rows on transient.calls_clone with no rows using the columns: "id", "rate_id", "route_id", "service_id".
Before merge
![image-20240430-135758](https://github.com/dadosfera/steps-public/assets/21319146/9f64ac19-d891-4cd8-b85b-805b181919b6)

After merge
![image-20240430-141851](https://github.com/dadosfera/steps-public/assets/21319146/47d674a2-6468-481d-b4a3-cb530f966255)
![image-20240430-141639](https://github.com/dadosfera/steps-public/assets/21319146/ad1246db-5240-4127-a88e-3750771c17a6)

2. Merge a DataFrame Pandas made by Faker() with 20 rows in Snowflake asset

Before merge, transient.calls_clone had 119 rows
After merge
![image-20240430-165552](https://github.com/dadosfera/steps-public/assets/21319146/ed9c8b45-e6f2-40f8-b7af-c4bcb001d45d)
![image-20240430-165621](https://github.com/dadosfera/steps-public/assets/21319146/1faaac29-9e20-48d7-85bb-b87e8c02e651)




