### PR TITLE
Step/get data from c2s

### DIFF
--- a/steps/get_data_from_c2s/README.md
+++ b/steps/get_data_from_c2s/README.md
@@ -1,0 +1,112 @@
+# Conector de Dados - Contact2Sale (C2S)
+
+Este passo (step) realiza a coleta de leads a partir da API da Contact2Sale, 
+respeitando a lógica de Full Load (quando não há histórico de execução) 
+e Incremental (quando já existe um registro de data/hora de atualização).
+
+## Step `get_data_from_cs2` 
+
+### Visão Geral
+
+Este conector interage com o endpoint:
+
+```
+  GET https://api.contact2sale.com/integration/leads
+```
+R
+respeitando:
+
+- Paginação via parâmetros page e perpage.
+- Limite de 10 requisições por minuto (para evitar bloqueio pela API).
+- Filtro incremental através de updated_gte, que retorna apenas leads atualizados a partir de uma data/hora específica.
+
+Caso não exista histórico de execução (primeira vez), é feita uma carga completa (full load), coletando todos os registros disponíveis. Em execuções subsequentes, o script obtém apenas os registros que foram atualizados após a última data registrada.
+
+### Arquivos e Variáveis Principais
+
+- get_data_from_c2s.py: Arquivo Python com a lógica de coleta, onde ficam as funções:
+    - get_last_update()
+    - save_last_update()
+    - fetch_data()
+    - find_max_updated_at()
+    - main()
+- last_update.json: Arquivo que armazena a última data/hora de atualização (formato ISO 8601 com Z no final). Se este arquivo não existir (ou estiver inválido), o script faz Full Load.
+
+#### Variáveis de Configuração:
+
+- BASE_URL: URL base para a API (ex.: https://api.contact2sale.com/integration/leads).
+- TOKEN: Token de autenticação (Bearer Token).
+- PER_PAGE: Quantidade de registros por página.
+- MAX_REQ_PER_MINUTE: Quantidade máxima de requisições a cada 60s (evita rate limit).
+- LAST_UPDATE_PATH: Caminho para o arquivo last_update.json.
+
+### Como Funciona o Fluxo
+
+1. Verificação do Arquivo de Histórico (`last_update.json`)
+
+- O script chama get_last_update() para verificar se existe uma data/hora salva.
+    - Se não existir, considera `None` → Full Load.
+    - Se existir (ex.: `"2024-12-27T10:46:28Z"`), o script usa esse valor → Incremental.
+
+2. Coleta dos Dados (`fetch_data()`)
+
+- Monta a requisição com parâmetros de paginação (`page`, `perpage`).
+- Se estiver em modo incremental, adiciona `updated_gte` ao params.
+- Executa requisições em loop até alcançar o total de registros informado pela API (data['meta']['total']).
+- Respeita o limite de 10 requisições/minuto, realizando `time.sleep(60)` quando atinge esse valor.
+
+3. Processamento Local e Salvamento
+
+- Todos os leads são acumulados em `all_results`.
+- Se houver algum destino (ex.: Snowflake), o script converte a lista de dicionários em DataFrame e grava na tabela configurada.
+
+4. Atualização do `updated_gte`
+
+- Ao final da coleta, o script chama `find_max_updated_at()` para descobrir a maior data/hora de atualização nos leads retornados.
+- Se encontrar um valor (`new_updated_gte`), ele é salvo em last_update.json pela função `save_last_update()`.
+
+5. Execução Futura
+
+- Na próxima execução, a função `get_last_update()` encontra esse valor
+    → o script busca apenas registros atualizados após esse timestamp, reduzindo a carga e tempo de processamento.
+    
+### Como Executar
+
+1. Instale Dependências
+
+- Verifique se possui requests, json, time e outras bibliotecas padrão do Python 3.
+- Caso vá gravar no Snowflake, instale snowflake-connector-python ou snowflake-snowpark-python.
+
+2. Configure as Variáveis
+
+- Ajuste BASE_URL para https://api.contact2sale.com/integration/leads.
+- Defina TOKEN com um Bearer Token válido na Contact2Sale.
+- Ajuste LAST_UPDATE_PATH, se desejar um caminho diferente (padrão: last_update.json).
+
+4. Rode o Script
+
+- Na primeira execução, o script não encontrará last_update.json e fará o full load.
+- Ao final, criará (ou atualizará) o arquivo last_update.json com o maior updated_at.
+- Na segunda execução, fará o modo incremental (apenas dados atualizados após a data armazenada).
+
+### Pontos de Atenção
+
+1. Número de Registros
+
+- Caso existam milhares de leads, o script pode demorar para terminar a carga inicial devido ao rate limit (10 requisições/minuto).
+- Ajuste PER_PAGE para o máximo permitido pela API (ex.: 50).
+
+2. Formato de Data
+
+- A Contact2Sale retorna datas no padrão ISO8601 (sem milissegundos).
+- A função find_max_updated_at() está preparada para strings do tipo YYYY-MM-DDTHH:MM:SSZ.
+
+3. Persistência
+
+- Após obter leads, você pode salvá-los em um arquivo local (JSON), banco de dados ou Snowflake.
+- Verifique se há necessidade de tratamento de duplicatas ou merges de atualização.
+
+4. Erros e Exceções
+
+- Se a API retornar erro (ex.: 401, 500), o script fará log do problema e a exceção será levantada.
+- Em caso de problemas de rede ou timeouts, revise a lógica de retry/timeout no requests.get().

--- a/steps/get_data_from_c2s/get_data_from_c2s.py
+++ b/steps/get_data_from_c2s/get_data_from_c2s.py
@@ -188,7 +188,6 @@ class C2SLead:
                 "[save_to_snowflake] Converting list to Snowpark DataFrame...")
             df_leads = snowpark.createDataFrame(all_results)
 
-            table_identifier = "DADOSFERA_PRD_IBRAM.PROLAR.TB_RAW_LEADS"
             logger.info(f"[save_to_snowflake] Saving DataFrame to table {
                         table_identifier} (append mode)...")
             df_leads.write.mode("append").save_as_table(table_identifier)

--- a/steps/get_data_from_c2s/get_data_from_c2s.py
+++ b/steps/get_data_from_c2s/get_data_from_c2s.py
@@ -1,0 +1,225 @@
+import os
+import sys
+import json
+import time
+import datetime
+import requests
+from typing import List, Dict
+import logging
+import orchest
+from dadosfera.services.snowflake import get_snowpark_session
+
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+BASE_URL = orchest.get_step_param('url')
+TOKEN = os.getenv('C2S_AUTHENTICATOR_TOKEN')
+
+
+LAST_UPDATE_PATH = "last_update.json"
+PER_PAGE = 50
+MAX_REQ_PER_MINUTE = 10
+
+
+def get_last_update():
+    """
+    Lê o 'last_update' de um arquivo JSON (LAST_UPDATE_PATH).
+    Retorna None se não existir ou se houver falha.
+    Exemplo: {"last_update": "2024-12-27T10:46:28Z"}
+    """
+    if not os.path.exists(LAST_UPDATE_PATH):
+        logger.info(f"[get_last_update] Arquivo {
+                    LAST_UPDATE_PATH} não encontrado. Retornando None.")
+        return None
+
+    try:
+        with open(LAST_UPDATE_PATH, "r") as f:
+            data = json.load(f)
+            last_update = data.get("last_update")
+            logger.info(
+                f"[get_last_update] last_update carregado: {last_update}")
+            return last_update
+    except Exception as e:
+        logger.error(f"[get_last_update] Erro ao carregar o arquivo {
+                     LAST_UPDATE_PATH}: {e}")
+        return None
+
+
+def save_last_update(timestamp_str):
+    """
+    Salva o timestamp (ex.: '2024-01-01T00:00:00Z') em arquivo JSON.
+    """
+    try:
+        with open(LAST_UPDATE_PATH, "w") as f:
+            json.dump({"last_update": timestamp_str}, f)
+        logger.info(f"[save_last_update] Valor '{
+                    timestamp_str}' salvo com sucesso em {LAST_UPDATE_PATH}.")
+    except Exception as e:
+        logger.error(f"[save_last_update] Erro ao salvar no arquivo {
+                     LAST_UPDATE_PATH}: {e}")
+        raise
+
+
+def fetch_data(last_update=None):
+    """
+    Faz a chamada à API, usando 'updated_gte' como filtro se existir.
+    Retorna a lista de leads.
+    Respeita a limitação de 10 requisições por minuto.
+    """
+    headers = {
+        'Authorization': f'Bearer {TOKEN}',
+        'Content-Type': 'application/json'
+
+    }
+    all_results = []
+    page = 1
+    count = 0
+
+    while True:
+        params = {
+            "page": page,
+            "perpage": PER_PAGE
+        }
+        # Só adiciona last_update se existir (ou seja, se não for a primeira execução).
+        if last_update:
+            params["updated_gte"] = last_update
+
+        logger.info(f"[fetch_data] Requisição página {
+                    page}, updated_gte={last_update}")
+        try:
+            response = requests.get(BASE_URL, headers=headers, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            leads = data.get("data", [])
+            if leads:
+                all_results.extend(leads)
+            total = data.get("meta", {}).get("total", 0)
+
+            logger.info(f"[fetch_data] Página {page} retornou {
+                        len(leads)} leads. total={total}")
+
+            # Se a paginação estiver concluída, saímos do loop
+            if (PER_PAGE * page) >= total:
+                logger.info(
+                    "[fetch_data] Finalizando a coleta (todas as páginas)...")
+                break
+
+            page += 1
+            count += 1
+
+            # api wait 10 req per minute
+            if count == MAX_REQ_PER_MINUTE:
+                logger.info(
+                    "[fetch_data] Limite de 10 req/min atingido: aguardando 60 segundos...")
+                time.sleep(60)
+                count = 0
+
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"[fetch_data] Request falhou na página {page}: {e}")
+            raise e
+        except Exception as e:
+            logger.error(f"[fetch_data] Erro inesperado na página {page}: {e}")
+            raise e
+
+    return all_results
+
+
+def find_max_updated_at(leads):
+    """
+    Percorre a lista de leads e identifica o maior valor de 'updated_at'.
+    Retorna o timestamp no formato 'YYYY-MM-DDTHH:MM:SSZ'.
+    """
+    max_dt = None
+
+    for lead in leads:
+        attributes = lead.get("attributes", {})
+        lu = attributes.get("updated_at")  # ex.: "2024-12-27T10:46:28Z"
+        if lu:
+            try:
+                dt = datetime.datetime.fromisoformat(lu.replace("Z", "+00:00"))
+                dt_utc = dt.astimezone(datetime.timezone.utc)
+                if not max_dt or dt > max_dt:
+                    max_dt = dt_utc
+            except ValueError:
+                # Caso o formato não seja compatível, ignora e segue
+                logger.warning(f"[find_max_updated_at] Formato inválido: {lu}")
+                pass
+
+    if max_dt:
+        formatted = max_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return formatted
+    return None
+
+
+def save_to_snowflake(snowpark, all_results):
+    """
+    Recebe a lista de leads (all_results) e salva no Snowflake via Snowpark.
+    """
+    try:
+        logger.info(
+            "[save_to_snowflake] Convertendo lista em DataFrame Snowpark...")
+        df_leads = snowpark.createDataFrame(all_results)
+
+        table_identifier = "DADOSFERA_PRD_IBRAM.PROLAR.TB_RAW_LEADS"
+        logger.info(f"[save_to_snowflake] Salvando DataFrame na tabela {
+                    table_identifier} (modo append)...")
+        df_leads.write.mode("append").save_as_table(table_identifier)
+        logger.info(f"[save_to_snowflake] DataFrame salvo com sucesso em {
+                    table_identifier}.")
+    except Exception as e:
+        logger.error(
+            f"[save_to_snowflake] Erro ao salvar dados no Snowflake: {e}")
+        raise e
+
+
+def main():
+    """
+    Fluxo principal
+    """
+    secret_id = os.getenv("SECRET_ID")
+    snowpark = get_snowpark_session(secret_id)
+    snowpark.use_warehouse('COMPUTE_WH')
+    snowpark.use_schema('PROLAR')
+
+    try:
+        last_update = get_last_update()
+        if last_update:
+            logger.info(
+                f"[main] INCREMENTAL a partir de updated_at={last_update}")
+        else:
+            logger.info("[main] FULL LOAD - Nenhum 'last_update' encontrado")
+
+        leads = fetch_data(last_update)
+        logger.info(f"[main] Total de registros obtidos: {len(leads)}")
+
+        if leads:
+            save_to_snowflake(snowpark, leads)
+            logger.info("[main] Salvando leads no Snowflake...")
+
+            new_last_update = find_max_updated_at(leads)
+            logger.info(f"[main] Valor encontrado: {new_last_update}")
+
+            if new_last_update:
+                save_last_update(new_last_update)
+                logger.info(f"[main] Arquivo '{LAST_UPDATE_PATH}' atualizado.")
+            else:
+                logger.info(
+                    "[main] Nenhum 'updated_at' válido encontrado; nada a salvar.")
+
+        else:
+            logger.info("[main] Nenhum lead retornado.")
+
+    except Exception as e:
+        logger.info(f"Ocorreu um erro: {e}")
+        raise
+    finally:
+        snowpark.close()
+
+
+if __name__ == "__main__":
+
+    main()

--- a/steps/get_data_from_c2s/get_data_from_c2s.py
+++ b/steps/get_data_from_c2s/get_data_from_c2s.py
@@ -10,216 +10,241 @@ import orchest
 from dadosfera.services.snowflake import get_snowpark_session
 
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
-
-BASE_URL = orchest.get_step_param('url')
-TOKEN = os.getenv('C2S_AUTHENTICATOR_TOKEN')
-
+ORCHEST_STEP_UUID = os.environ.get('ORCHEST_STEP_UUID')
 
 LAST_UPDATE_PATH = "last_update.json"
 PER_PAGE = 50
 MAX_REQ_PER_MINUTE = 10
 
 
-def get_last_update():
+class C2SLead:
     """
-    Lê o 'last_update' de um arquivo JSON (LAST_UPDATE_PATH).
-    Retorna None se não existir ou se houver falha.
-    Exemplo: {"last_update": "2024-12-27T10:46:28Z"}
+    Class to fetch leads from C2S API.
+
+    Attributes:
+    - logger: logging.Logger
+    - instance_url: str
+    - token: str
     """
-    if not os.path.exists(LAST_UPDATE_PATH):
-        logger.info(f"[get_last_update] Arquivo {
-                    LAST_UPDATE_PATH} não encontrado. Retornando None.")
-        return None
 
-    try:
-        with open(LAST_UPDATE_PATH, "r") as f:
-            data = json.load(f)
-            last_update = data.get("last_update")
-            logger.info(
-                f"[get_last_update] last_update carregado: {last_update}")
-            return last_update
-    except Exception as e:
-        logger.error(f"[get_last_update] Erro ao carregar o arquivo {
-                     LAST_UPDATE_PATH}: {e}")
-        return None
+    def __init__(
+        self,
+        logger: logging.Logger,
+        instance_url: str,
+        token: str
+    ):
+        self.logger = logger
+        self.instance_url = instance_url
+        self.token = token
 
+    def get_last_update(self):
+        """
+        Reads the 'last_update' from a JSON file (LAST_UPDATE_PATH).
+        Returns None if it doesn't exist or if there's a failure.
+        Example: {"last_update": "2024-12-27T10:46:28Z"}
+        """
+        if not os.path.exists(LAST_UPDATE_PATH):
+            self.logger.info(f"[get_last_update] File {
+                             LAST_UPDATE_PATH} not found. Returning None.")
+            return None
 
-def save_last_update(timestamp_str):
-    """
-    Salva o timestamp (ex.: '2024-01-01T00:00:00Z') em arquivo JSON.
-    """
-    try:
-        with open(LAST_UPDATE_PATH, "w") as f:
-            json.dump({"last_update": timestamp_str}, f)
-        logger.info(f"[save_last_update] Valor '{
-                    timestamp_str}' salvo com sucesso em {LAST_UPDATE_PATH}.")
-    except Exception as e:
-        logger.error(f"[save_last_update] Erro ao salvar no arquivo {
-                     LAST_UPDATE_PATH}: {e}")
-        raise
-
-
-def fetch_data(last_update=None):
-    """
-    Faz a chamada à API, usando 'updated_gte' como filtro se existir.
-    Retorna a lista de leads.
-    Respeita a limitação de 10 requisições por minuto.
-    """
-    headers = {
-        'Authorization': f'Bearer {TOKEN}',
-        'Content-Type': 'application/json'
-
-    }
-    all_results = []
-    page = 1
-    count = 0
-
-    while True:
-        params = {
-            "page": page,
-            "perpage": PER_PAGE
-        }
-        # Só adiciona last_update se existir (ou seja, se não for a primeira execução).
-        if last_update:
-            params["updated_gte"] = last_update
-
-        logger.info(f"[fetch_data] Requisição página {
-                    page}, updated_gte={last_update}")
         try:
-            response = requests.get(BASE_URL, headers=headers, params=params)
-            response.raise_for_status()
-            data = response.json()
-
-            leads = data.get("data", [])
-            if leads:
-                all_results.extend(leads)
-            total = data.get("meta", {}).get("total", 0)
-
-            logger.info(f"[fetch_data] Página {page} retornou {
-                        len(leads)} leads. total={total}")
-
-            # Se a paginação estiver concluída, saímos do loop
-            if (PER_PAGE * page) >= total:
-                logger.info(
-                    "[fetch_data] Finalizando a coleta (todas as páginas)...")
-                break
-
-            page += 1
-            count += 1
-
-            # api wait 10 req per minute
-            if count == MAX_REQ_PER_MINUTE:
-                logger.info(
-                    "[fetch_data] Limite de 10 req/min atingido: aguardando 60 segundos...")
-                time.sleep(60)
-                count = 0
-
-        except requests.exceptions.HTTPError as e:
-            logger.error(f"[fetch_data] Request falhou na página {page}: {e}")
-            raise e
+            with open(LAST_UPDATE_PATH, "r") as f:
+                data = json.load(f)
+                last_update = data.get("last_update")
+                self.logger.info(
+                    f"[get_last_update] Loaded last_update {last_update}")
+                return last_update
         except Exception as e:
-            logger.error(f"[fetch_data] Erro inesperado na página {page}: {e}")
-            raise e
+            self.logger.error(f"[get_last_update] Error loading file{
+                              LAST_UPDATE_PATH}: {e}")
+            return None
 
-    return all_results
+    def save_last_update(self, timestamp_str):
+        """
+        Saves the 'last_update' to a JSON file (LAST_UPDATE_PATH).
+        """
+        try:
+            with open(LAST_UPDATE_PATH, "w") as f:
+                json.dump({"last_update": timestamp_str}, f)
+            self.logger.info(f"[save_last_update] Saved '{timestamp_str}' to {
+                             LAST_UPDATE_PATH} successfully.")
+        except Exception as e:
+            self.logger.error(f"[save_last_update] Error saving file {
+                              LAST_UPDATE_PATH}: {e}")
+            raise
 
+    def fetch_data(self, last_update=None):
+        """
+        Fetches all leads from the C2S API.
+        last_update: str - ISO 8601 format (ex.: "2024-12-27T10:46:28Z")
+        Returns a list of leads (dicts).
+        """
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json'
 
-def find_max_updated_at(leads):
-    """
-    Percorre a lista de leads e identifica o maior valor de 'updated_at'.
-    Retorna o timestamp no formato 'YYYY-MM-DDTHH:MM:SSZ'.
-    """
-    max_dt = None
+        }
+        all_results = []
+        page = 1
+        count = 0
 
-    for lead in leads:
-        attributes = lead.get("attributes", {})
-        lu = attributes.get("updated_at")  # ex.: "2024-12-27T10:46:28Z"
-        if lu:
+        while True:
+            params = {
+                "page": page,
+                "perpage": PER_PAGE
+            }
+
+            if last_update:
+                params["updated_gte"] = last_update
+
+            self.logger.info(f"[fetch_data] Requesting page {
+                             page}, updated_gte={last_update}")
             try:
-                dt = datetime.datetime.fromisoformat(lu.replace("Z", "+00:00"))
-                dt_utc = dt.astimezone(datetime.timezone.utc)
-                if not max_dt or dt > max_dt:
-                    max_dt = dt_utc
-            except ValueError:
-                # Caso o formato não seja compatível, ignora e segue
-                logger.warning(f"[find_max_updated_at] Formato inválido: {lu}")
-                pass
+                response = requests.get(
+                    self.instance_url, headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
 
-    if max_dt:
-        formatted = max_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        return formatted
-    return None
+                leads = data.get("data", [])
+                if leads:
+                    all_results.extend(leads)
+                total = data.get("meta", {}).get("total", 0)
 
+                self.logger.info(f"[fetch_data] Page {page} returned {
+                                 len(leads)} leads. Total={total}")
 
-def save_to_snowflake(snowpark, all_results):
-    """
-    Recebe a lista de leads (all_results) e salva no Snowflake via Snowpark.
-    """
-    try:
-        logger.info(
-            "[save_to_snowflake] Convertendo lista em DataFrame Snowpark...")
-        df_leads = snowpark.createDataFrame(all_results)
+                if (PER_PAGE * page) >= total:
+                    self.logger.info(
+                        "[fetch_data] Completed fetching all pages.")
+                    break
 
-        table_identifier = "DADOSFERA_PRD_IBRAM.PROLAR.TB_RAW_LEADS"
-        logger.info(f"[save_to_snowflake] Salvando DataFrame na tabela {
-                    table_identifier} (modo append)...")
-        df_leads.write.mode("append").save_as_table(table_identifier)
-        logger.info(f"[save_to_snowflake] DataFrame salvo com sucesso em {
-                    table_identifier}.")
-    except Exception as e:
-        logger.error(
-            f"[save_to_snowflake] Erro ao salvar dados no Snowflake: {e}")
-        raise e
+                page += 1
+                count += 1
 
+                # api wait 10 req per minute
+                if count == MAX_REQ_PER_MINUTE:
+                    self.logger.info(
+                        "[fetch_data] Rate limit reached: waiting 60 seconds...")
+                    time.sleep(60)
+                    count = 0
 
-def main():
-    """
-    Fluxo principal
-    """
-    secret_id = os.getenv("SECRET_ID")
-    snowpark = get_snowpark_session(secret_id)
-    snowpark.use_warehouse('COMPUTE_WH')
-    snowpark.use_schema('PROLAR')
+            except requests.exceptions.HTTPError as e:
+                self.logger.error(
+                    f"[fetch_data] Request failed on page {page}: {e}")
+                raise e
+            except Exception as e:
+                logger.error(
+                    f"[fetch_data] Unexpected error on page {page}: {e}")
+                raise e
 
-    try:
-        last_update = get_last_update()
-        if last_update:
-            logger.info(
-                f"[main] INCREMENTAL a partir de updated_at={last_update}")
-        else:
-            logger.info("[main] FULL LOAD - Nenhum 'last_update' encontrado")
+        return all_results
 
-        leads = fetch_data(last_update)
-        logger.info(f"[main] Total de registros obtidos: {len(leads)}")
+    def find_max_updated_at(self, leads):
+        """
+        Finds the maximum 'updated_at' timestamp from a list of leads.
+        Returns a string in ISO 8601 format (ex.: "2024-12-27T10:46:28Z").
+        """
+        max_dt = None
 
-        if leads:
-            save_to_snowflake(snowpark, leads)
-            logger.info("[main] Salvando leads no Snowflake...")
+        for lead in leads:
+            attributes = lead.get("attributes", {})
+            lu = attributes.get("updated_at")  # ex.: "2024-12-27T10:46:28Z"
+            if lu:
+                try:
+                    dt = datetime.datetime.fromisoformat(
+                        lu.replace("Z", "+00:00"))
+                    dt_utc = dt.astimezone(datetime.timezone.utc)
+                    if not max_dt or dt > max_dt:
+                        max_dt = dt_utc
+                except ValueError:
+                    # Caso o formato não seja compatível, ignora e segue
+                    self.logger.warning(
+                        f"[find_max_updated_at] Invalid format:  {lu}")
+                    pass
 
-            new_last_update = find_max_updated_at(leads)
-            logger.info(f"[main] Valor encontrado: {new_last_update}")
+        return max_dt.strftime("%Y-%m-%dT%H:%M:%SZ") if max_dt else None
 
-            if new_last_update:
-                save_last_update(new_last_update)
-                logger.info(f"[main] Arquivo '{LAST_UPDATE_PATH}' atualizado.")
+    def run(self):
+        """
+        Main method to orchestrate the process.
+        """
+
+        try:
+            last_update = self.get_last_update()
+            if last_update:
+                self.logger.info(
+                    f"[run] Incremental load from updated_at={last_update}")
             else:
-                logger.info(
-                    "[main] Nenhum 'updated_at' válido encontrado; nada a salvar.")
+                self.logger.info("[run] Full load - No 'last_update' found.")
 
-        else:
-            logger.info("[main] Nenhum lead retornado.")
+            leads = self.fetch_data(last_update)
+            logger.info(f"[main] Total leads fetched: {len(leads)}")
 
-    except Exception as e:
-        logger.info(f"Ocorreu um erro: {e}")
-        raise
-    finally:
-        snowpark.close()
+            if leads:
+                new_last_update = self.find_max_updated_at(leads)
+                if new_last_update:
+                    self.save_last_update(new_last_update)
+                else:
+                    self.logger.info(
+                        "[run] No valid 'updated_at' found to save.")
+
+        except Exception as e:
+            self.logger.error(f"Error occured: {e}")
+            raise
+
+
+def orchest_handler():
+    base_url = orchest.get_step_param('url')
+    token = os.getenv("C2S_AUTHENTICATOR_TOKEN")
+
+    if not token:
+        raise Exception("C2S_AUTHENTICATOR_TOKEN is required")
+
+    handler = C2SLead(
+        logger=logger,
+        instance_url=base_url,
+        token=token
+    )
+    handler.run()
+
+
+def script_handler():
+    if len(sys.argv) != 2:
+        raise Exception(
+            "Please provide the required configuration in JSON format")
+    config_json = sys.argv[1]
+    config = json.loads(config_json)
+
+    base_url = config.get("url")
+    token = config.get("token")
+
+    if not base_url or not token:
+        raise ValueError(
+            "Both 'url' and 'token' must be provided in the configuration.")
+
+    handler = C2SLead(
+        logger=logger,
+        instance_url=base_url,
+        token=token
+    )
+    handler.run()
 
 
 if __name__ == "__main__":
 
-    main()
+    if ORCHEST_STEP_UUID is not None:
+        logger.info("Running as Orchest Step")
+        orchest_handler()
+    else:
+        logger.info("Running as script")
+        script_handler()

--- a/steps/get_data_from_c2s/get_data_from_c2s.schema.json
+++ b/steps/get_data_from_c2s/get_data_from_c2s.schema.json
@@ -4,7 +4,11 @@
         "instance_url": {
             "description": "Base URL for the inteligence module",
             "type": "string"
+        },
+        "table_identifier": {
+            "description": "Table identifier for the saved data",
+            "type": "string"
         }
     },
-    "required": ["instance_url"]
+    "required": ["instance_url", "table_identifier"]
 }

--- a/steps/get_data_from_c2s/get_data_from_c2s.schema.json
+++ b/steps/get_data_from_c2s/get_data_from_c2s.schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "instance_url": {
+            "description": "Base URL for the inteligence module",
+            "type": "string"
+        }
+    },
+    "required": ["instance_url"]
+}

--- a/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
+++ b/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
@@ -21,7 +21,7 @@
                         {
                             "type": "Control",
                             "scope": "#/properties/table_identifier",
-                            "label": "Table Identifier for the Saved Data - ex: NAMEOFTHEBANK.SCHEMANAME.TABLENAME"
+                            "label": "Table Identifier for the Saved Data (e.g., <DATABASE_NAME>.<SCHEMA_NAME>.<TABLE_NAME>). Leave blank if saving data is not required."
                         }
                     ]
                 }

--- a/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
+++ b/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
@@ -1,0 +1,21 @@
+{
+    "type": "Categorization",
+    "elements": [
+        {
+            "type": "Category",
+            "label": "Main Configuration",
+            "elements": [
+                {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                        {
+                            "type": "Control",
+                            "scope": "#/properties/instance_url",
+                            "label": "Platform API Base URL"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
+++ b/steps/get_data_from_c2s/get_data_from_c2s.uischema.json
@@ -14,6 +14,16 @@
                             "label": "Platform API Base URL"
                         }
                     ]
+                },
+                {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                        {
+                            "type": "Control",
+                            "scope": "#/properties/table_identifier",
+                            "label": "Table Identifier for the Saved Data - ex: NAMEOFTHEBANK.SCHEMANAME.TABLENAME"
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
This PR introduces a generic step for fetching C2S lead data, designed to run both in the Orchest platform (via orchest_handler) and as a standalone script (via script_handler). The implementation includes:

- A reusable C2SLead class that handles fetching, processing, and storing last_update timestamps for incremental data fetching.
- Integration with Orchest step parameters for dynamic configuration during pipeline execution.
- Support for local execution by accepting configuration in JSON format as a script argument.
- Logging and error handling improvements for better monitoring and debugging.
- Adherence to API rate limits with paginated data fetching.