### PR TITLE
Docs: credenciais via secret_id e compatibilidade com Python 3.8 no checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Passo a passo completo: [2. Desenvolvendo um Step](https://github.com/dadosfera/
 - [ ] Três arquivos com o *sidecar naming* correto, no mesmo diretório
 - [ ] Todo parâmetro lido no `.py` existe no `schema.json` e aparece no `uischema.json`
 - [ ] Lógica de negócio em função pura, separada dos handlers, com type hints
-- [ ] `logger` em vez de `print`; nenhum segredo no código
+- [ ] `logger` em vez de `print`; credencial via `secret_id` (AWS Secrets Manager), nunca em código, schema ou log
+- [ ] Compatível com **Python 3.8** (runtime da plataforma) — validado na imagem, não só no Python local
 - [ ] Roda local via docker compose
 - [ ] Validado em um ambiente `dadosfera-ai-oss`: formulário renderiza e execução passa
 - [ ] `README.md` do step e este catálogo atualizados


### PR DESCRIPTION
Ajusta o checklist de PR do README para refletir dois padrões reais do repositório que estavam subespecificados:

- **Credenciais**: o padrão não é "nenhum segredo no código" genérico — é `secret_id` apontando para o AWS Secrets Manager, lido em runtime (`get_snowpark_session(secret_id)` nos steps de Snowflake, como `standardized_tables_union_all` e `save_data_in_snowflake_using_copy`). O item agora nomeia o padrão e inclui schema e log como superfícies proibidas.
- **Python 3.8**: é o runtime da plataforma. O Python local do desenvolvedor é mais novo, então sintaxe 3.9+ (`dict[str, int]`, `X | None`) passa no teste local e quebra no import dentro do container. O checklist agora exige validação na versão certa.

Mesmos ajustes aplicados em [`steps-fera/docs`](https://github.com/dadosfera/steps-fera/tree/main/docs) e no README do `steps-private`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
